### PR TITLE
solve the memory leak problem of web-demo

### DIFF
--- a/demos/web/server.py
+++ b/demos/web/server.py
@@ -355,6 +355,7 @@ class OpenFaceServerProtocol(WebSocketServerProtocol):
                 "type": "ANNOTATED",
                 "content": content
             }
+            plt.close()
             self.sendMessage(json.dumps(msg))
 
 if __name__ == '__main__':


### PR DESCRIPTION
The web demo will show the warning:more than 20 figures have opened,and the memory occupation keep raising,because the figure object need to be explicitly closed otherwise it will consume too much memory while the demo is running. 