### PR TITLE
check for presence of 'classifierModel' argument before trying to parse

### DIFF
--- a/demos/classifier.py
+++ b/demos/classifier.py
@@ -145,7 +145,7 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
 
-    if args.classifierModel.endswith(".t7"):
+    if hasattr(args, 'classifierModel') and args.classifierModel.endswith(".t7"):
         raise Exception("""
 Torch network model passed as the classification model.
 


### PR DESCRIPTION
fixes a bug in the classifier demo where if you use the train argument there is no classifierModel argument present and the script fails. This fix simply checks to make sure the argument is there before trying to do anything with it.