### PR TITLE
Added optnet for reducing memory consumption

### DIFF
--- a/training/model.lua
+++ b/training/model.lua
@@ -37,6 +37,8 @@ if opt.cuda then
    criterion:cuda()
 end
 
+optimizeNet(model, imgDim)
+
 print('=> Model')
 print(model)
 print(('Number of Parameters: %d'):format(model:getParameters():size(1)))

--- a/training/util.lua
+++ b/training/util.lua
@@ -57,11 +57,11 @@ end
 
 --Reduce the memory consumption by model by sharing the buffers
 function optimizeNet( model, inputSize )
-   optnet = require 'optnet'
-   opts   = {inplace=true, mode='training',removeGradParams=false}
-   input  = torch.Tensor(1,3,inputSize,inputSize)
+   local optnet = require 'optnet'
+   local opts   = {inplace=true, mode='training', removeGradParams=false}
+   local input  = torch.Tensor(1,3,inputSize,inputSize)
    if opt.cuda then
       input = input:cuda()
    end
-   optnet.optimizeMemory(model, input,opts)
+   optnet.optimizeMemory(model, input, opts)
 end

--- a/training/util.lua
+++ b/training/util.lua
@@ -54,3 +54,14 @@ function receiveTensor(obj, buffer)
    end
    return buffer
 end
+
+--Reduce the memory consumption by model by sharing the buffers
+function optimizeNet( model, inputSize )
+   optnet = require 'optnet'
+   opts   = {inplace=true, mode='training',removeGradParams=false}
+   input  = torch.Tensor(1,3,inputSize,inputSize)
+   if opt.cuda then
+      input = input:cuda()
+   end
+   optnet.optimizeMemory(model, input,opts)
+end

--- a/training/util.lua
+++ b/training/util.lua
@@ -57,11 +57,15 @@ end
 
 --Reduce the memory consumption by model by sharing the buffers
 function optimizeNet( model, inputSize )
-   local optnet = require 'optnet'
-   local opts   = {inplace=true, mode='training', removeGradParams=false}
-   local input  = torch.Tensor(1,3,inputSize,inputSize)
-   if opt.cuda then
-      input = input:cuda()
+   local optnet_loaded, optnet = pcall(require,'optnet')
+   if  optnet_loaded then
+      local opts   = {inplace=true, mode='training', removeGradParams=false}
+      local input  = torch.Tensor(1,3,inputSize,inputSize)
+      if opt.cuda then
+          input = input:cuda()
+      end
+      optnet.optimizeMemory(model, input, opts)
+   else
+      print("'optnet' package not found, please install it to reduce the memory consumption, repo https://github.com/fmassa/optimize-net")
    end
-   optnet.optimizeMemory(model, input, opts)
 end


### PR DESCRIPTION
### What does this PR do?
Reduce memory consumption thanks to https://github.com/fmassa/optimize-net. For example, memory consumption from nn4 model was reduced by 33%

### How should this PR be tested?
It should be tested by running several training procedure, using different models and batch size


### What are the relevant issues?
#106 

# Questions:
@fmassa currently you method works slightly worse than pure "shareGradient" idea. Do you know why? (difference is ~50 Mb in model which use 3.5 Gb)
@bamos should this method be run as default or chosen by command line option. I was thinking about only because for using it, the user need to install additional dependence

+ Does this PR add new (Python) dependencies?

This method use https://github.com/fmassa/optimize-net and it should be installed. 
