### PR TITLE
Docker config changes supporting TLS (part 2). 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,11 +23,12 @@ RUN apt-get update && apt-get install -y \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ADD . /root/openface
+RUN python -m pip install --upgrade --force pip
 RUN cd ~/openface && \
     ./models/get-models.sh && \
     pip2 install -r requirements.txt && \
     python2 setup.py install && \
-    pip2 install -r demos/web/requirements.txt && \
+    pip2 install --user --ignore-installed -r demos/web/requirements.txt && \
     pip2 install -r training/requirements.txt
 
 EXPOSE 8000 9000


### PR DESCRIPTION
### What does this PR do?
This fixes an issue with pip and some of the dependent libraries that was breaking the docker build. These dependencies are required to support TLS in the web demo.

### Where should the reviewer start?

### How should this PR be tested?
Building the docker image should be sufficient. (It should work)

I successfully built the docker image (and ran the web demo) on both MacOs Sierra and Ubuntu 12.0.4. It does not build on Win10 due to an unrelated bug (or perhaps just my system). 

### Any background context you want to provide?
There was a pip versioning issue with some of the nested dependencies. Forcing an update of pip and ignoring os-installed packages fixes the issue. 

### What are the relevant issues?
#262 

# Screenshots (if appropriate)

# Questions:

+ Do the docs need to be updated?
Yes. The web demo docker instructions are not correct. The proper command to invoke the web demo via docker is: docker run -p 9000:9000 -p 8000:8000 -t -i bamos/openface (might need to run this with sudo on ubuntu) Then go to https://dockerip:8000 and accept the cert.
+ Does this PR add new (Python) dependencies?
No