### PR TITLE
Update classifier.py

### DIFF
--- a/demos/classifier.py
+++ b/demos/classifier.py
@@ -37,7 +37,7 @@ import pandas as pd
 import openface
 
 from sklearn.pipeline import Pipeline
-from sklearn.lda import LDA
+from sklearn.discriminant_analysis import LinearDiscriminantAnalysis as LDA
 from sklearn.preprocessing import LabelEncoder
 from sklearn.svm import SVC
 from sklearn.grid_search import GridSearchCV


### PR DESCRIPTION
Updating import to fix deprecation warning

### What does this PR do?

It updates the `from sklearn.lda import LDA` to `from sklearn.discriminant_analysis import LinearDiscriminantAnalysis as LDA` to fix the deprecation warning when running the script

### Where should the reviewer start?

### How should this PR be tested?
Run the demo (`./demos/classifier.py infer ./models/openface/celeb-classifier.nn4.small2.v1.pkl images/examples/{carell,adams,lennon}*`

### Any background context you want to provide?

### What are the relevant issues?

[You can link directly to issues by entering # then the
number of the issue, for example, #3 links to issue 3]

# Screenshots (if appropriate)

# Questions:

+ Do the docs need to be updated?
No
+ Does this PR add new (Python) dependencies?
A sklearn version > 0.17 (November 2015)
http://scikit-learn.org/stable/whats_new.html#version-0-17
https://github.com/scikit-learn/scikit-learn/commit/085308c715178a96737629b2275facad2134eb52
