### PR TITLE
Fix deprecated method in web demo.

### DIFF
--- a/demos/web/index.html
+++ b/demos/web/index.html
@@ -217,10 +217,12 @@ limitations under the License.
      $("#trainingChk").bootstrapToggle('off');
      $("#peopleInVideo").html("");
 
-     if (navigator.getUserMedia) {
-         var videoSelector = {video : true};
-         navigator.getUserMedia(videoSelector, umSuccess, function() {
-             alert("Error fetching video from webcam");
+     if (navigator.mediaDevices.getUserMedia) {
+       var videoSelector = {video : true};
+       navigator.mediaDevices.getUserMedia(videoSelector)
+         .then(umSuccess)
+         .catch(function() {
+           alert("Error fetching video from webcam");
          });
      } else {
          alert("No webcam detected.");


### PR DESCRIPTION
### What does this PR do?

Fix deprecated method in web demo.

### Where should the reviewer start?

Load the demo in Chrome and ensure it works.

### How should this PR be tested?

Load the demo in Chrome and ensure it works.

### Any background context you want to provide?

Navigator.getUserMedia() which have been removed from the Web standards and is in the process of being dropped. We're advised to not use it and instead use the newer navigator.mediaDevices.getUserMedia() method instead.

Quote from MDN:

> This is a legacy method. Please use the newer navigator.mediaDevices.getUserMedia() instead. While technically not deprecated, this old callback version is marked as such, since the specification strongly encourages using the newer promise returning version.
> 
> Deprecated
> This feature has been removed from the Web standards. Though some browsers may still support it, it is in the process of being dropped. Avoid using it and update existing code if possible; see the compatibility table at the bottom of this page to guide your decision. Be aware that this feature may cease to work at any time.

### What are the relevant issues?

n/a

# Screenshots (if appropriate)

 n/a

# Questions:

+ Do the docs need to be updated? No
+ Does this PR add new (Python) dependencies? No
