### PR TITLE
Fix typo in acknowledgements section

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -174,8 +174,8 @@ CMU-CS-16-118, CMU School of Computer Science, Tech. Rep., 2016.
   example code.
 + [Davis King's](https://github.com/davisking) [dlib](https://github.com/davisking/dlib)
   library for face detection and alignment.
-+ The GitHub issue and pull request templates are inspired from
-  [Randy Olsen's](http://www.randalolson.com/) templates at [rhiever/tpot](https://github.com/rhiever/tpot),
++ The GitHub issue and pull request templates are inspired by
+  [Randy Olson's](http://www.randalolson.com/) templates at [rhiever/tpot](https://github.com/rhiever/tpot),
   [Justin Abrahms'](https://justin.abrah.ms/) [PR template](https://quickleft.com/blog/pull-request-templates-make-code-review-easier/),
   and
   [Aurelia Moser's](http://algorhyth.ms/) [issue template](https://bl.ocks.org/auremoser/72803ba969d0e61ff070).


### PR DESCRIPTION
### What does this PR do?

Fixes a minor typo in the acknowledgements section -- Randy (@rhiever) usually prefers "Olson" over "Olsen" :)

### Where should the reviewer start?

-

### How should this PR be tested?

-

### Any background context you want to provide?

-

### What are the relevant issues?

-

# Screenshots (if appropriate)

-

# Questions:

+ Do the docs need to be updated?

needs a `mkdocs gh-deploy`, but it's just a minor typo fix, so nothing not urgent.

+ Does this PR add new (Python) dependencies?

no
