### PR TITLE
Remove usage of deprecated mozilla api

### DIFF
--- a/demos/web/js/openface-demo.js
+++ b/demos/web/js/openface-demo.js
@@ -233,11 +233,7 @@ function createSocket(address, name) {
 }
 
 function umSuccess(stream) {
-    if (vid.mozCaptureStream) {
-        vid.mozSrcObject = stream;
-    } else {
-        vid.srcObject = stream;
-    }
+    vid.srcObject = stream;
     vid.play();
     vidReady = true;
     sendFrameLoop();


### PR DESCRIPTION
This API is no longer working in the current Firefox version (69)
There is also a similar discussion here: https://github.com/webrtc/samples/issues/302
This fixes #319